### PR TITLE
feat(backend): add lux estimation and mean pixel intensity fallback

### DIFF
--- a/backend/app/emotion_classifier/service/ambience_emotion_classification_service.py
+++ b/backend/app/emotion_classifier/service/ambience_emotion_classification_service.py
@@ -1,0 +1,71 @@
+import os
+import cv2
+import math
+import tempfile
+import numpy as np
+from PIL import Image, ExifTags
+
+
+class AmbienceEmotionClassifactionService:
+    MD2_LUX_HASH = "67b2177e9e29e113246fed14c6915448"
+    MD2_ISO_HASH = "ba07c6ca57ada953ce1dbaa4e98cb8e5"
+    MD2_BRIGHTNESS_HASH = "e67d288bc38db3a940c17b8c8a2c1acf"
+
+    @classmethod
+    def _extract_exif(cls, image_path):
+        img = Image.open(image_path)
+        exif = img._getexif()
+
+        if not exif:
+            return None
+
+        exif_data = {}
+
+        for tag, value in exif.items():
+            tag_name = ExifTags.TAGS.get(tag, tag)
+            exif_data[tag_name] = value
+
+        return {
+            "aperture": exif_data.get("FNumber"),
+            "shutter": exif_data.get("ExposureTime"),
+            "iso": exif_data.get("ISOSpeedRatings"),
+        }
+
+    @classmethod
+    def _compute_lux(cls, aperture, shutter_speed, iso=100, k=2.5):
+        if (not aperture) or (not shutter_speed):
+            return -1
+
+        N, t = aperture, shutter_speed
+        ev = math.log2((N**2) / t)
+
+        ev100 = ev - math.log2(iso / 100)
+
+        return k * (2**ev100)
+
+    @classmethod
+    def _compute_mean_brightness(cls, image_path):
+        img = cv2.imread(image_path)
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        return np.mean(gray) * 0.45
+
+    @classmethod
+    def process_uploaded_image(cls, file):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".jpg") as tmp:
+            tmp.write(file.read())
+            tmp_path = tmp.name
+
+        meta = cls._extract_exif(tmp_path)
+
+        lux = (
+            cls._compute_lux(meta["aperture"], meta["shutter"], meta["iso"])
+            if meta
+            else -1
+        )
+        brightness = cls._compute_mean_brightness(tmp_path)
+
+        return {
+            cls.MD2_LUX_HASH: lux,
+            cls.MD2_BRIGHTNESS_HASH: brightness,
+            cls.MD2_ISO_HASH: meta["iso"] if meta["iso"] else -1,
+        }

--- a/backend/app/emotion_classifier/urls.py
+++ b/backend/app/emotion_classifier/urls.py
@@ -3,11 +3,18 @@ from .viewsets.text_emotion_classification_viewset import (
     TextEmotionClassificationView,
     BatchTextEmotionClassificationView,
 )
+from .viewsets.ambience_emotion_classification_viewset import (
+    AmbienceEmotionClassificationViewset,
+)
 
 urlpatterns = [
     path("text/", TextEmotionClassificationView.as_view()),
     path(
         "text/batch/",
         BatchTextEmotionClassificationView.as_view(),
+    ),
+    path(
+        "ambience/process_image/",
+        AmbienceEmotionClassificationViewset.as_view({"post": "process_image"}),
     ),
 ]

--- a/backend/app/emotion_classifier/viewsets/ambience_emotion_classification_viewset.py
+++ b/backend/app/emotion_classifier/viewsets/ambience_emotion_classification_viewset.py
@@ -1,0 +1,19 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
+from rest_framework.response import Response
+from ..service.ambience_emotion_classification_service import (
+    AmbienceEmotionClassifactionService,
+)
+
+
+class AmbienceEmotionClassificationViewset(ViewSet):
+    def process_image(self, request, *args, **kwargs):
+        image_file = request.FILES.get("image")
+        if not image_file:
+            return Response({"error": "No image provided"}, status=HTTP_400_BAD_REQUEST)
+
+        metadata = AmbienceEmotionClassifactionService.process_uploaded_image(
+            image_file
+        )
+
+        return Response(metadata, status=HTTP_200_OK)


### PR DESCRIPTION
#### Added AmbienceEmotionClassificationService:

- _extract_exif() → parses EXIF metadata (aperture, shutter speed, ISO).
- _compute_lux() → estimates lux from exposure values when metadata is present.
- _compute_mean_brightness() → computes grayscale mean intensity (scaled) as fallback when EXIF is unavailable.
- process_uploaded_image() → processes uploaded image, computes lux & brightness, and returns normalized values.